### PR TITLE
bug:[65] Add conditional formatting for between

### DIFF
--- a/examples/vanilla-js-demo/conditionFormattingPopUp.js
+++ b/examples/vanilla-js-demo/conditionFormattingPopUp.js
@@ -134,8 +134,8 @@ function addCondition(container) {
   const valueRow = createFormRow('Value:', [
     createSelect(['All values', 'Number', 'Text']),
     createSelect(['Greater than', 'Less than', 'Equal to','Between']), // Add 'Between' to list in future.
-    createInput('text', ''),
-    createInput('text', ''),
+    createInput('text', '', 'Enter value 1'),
+    createInput('text', '', 'For between enter value 2'),
   ]);
 
   // Add "between" input when needed
@@ -232,10 +232,11 @@ function createSelect(options) {
   return select;
 }
 
-function createInput(type, value) {
+function createInput(type, value,placeholder='') {
   const input = document.createElement('input');
   input.type = type;
   input.value = value;
+  input.placeholder = placeholder
   input.style.padding = '8px';
   input.style.border = '1px solid #d1d5db';
   input.style.borderRadius = '4px';

--- a/examples/vanilla-js-demo/conditionFormattingPopUp.js
+++ b/examples/vanilla-js-demo/conditionFormattingPopUp.js
@@ -133,7 +133,8 @@ function addCondition(container) {
   // Value row
   const valueRow = createFormRow('Value:', [
     createSelect(['All values', 'Number', 'Text']),
-    createSelect(['Greater than', 'Less than', 'Equal to']), // Add 'Between' to list in future.
+    createSelect(['Greater than', 'Less than', 'Equal to','Between']), // Add 'Between' to list in future.
+    createInput('text', ''),
     createInput('text', ''),
   ]);
 
@@ -344,7 +345,6 @@ export function conditionFormattingPopUp(config) {
 
   createConditionFormattingPopup({
     onApply: (conditions) => {
-      console.log('Applied conditions:', conditions);
       // Update the formatting configuration
       if (!config.hasOwnProperty('conditionalFormatting')) {
         config.conditionalFormatting = [];
@@ -354,7 +354,7 @@ export function conditionFormattingPopUp(config) {
       applyConditionalFormatting(config);
     },
     onCancel: () => {
-      console.log('Conditional formatting cancelled');
+      console.warn('Conditional formatting cancelled');
     },
   });
 }


### PR DESCRIPTION
# Pull Request Description

This pull request addresses the following issue:

**Feature**: [GitHub Issue #63 ](https://github.com/mindfiredigital/PivotHead/issues/63)

### Changes Made:

-  Add option for selecting 'Between'
-  Able to condition formatting on UI using between two values.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/64b65466-3e5b-43d0-8c29-5383b246352e)

### Checklist:

- [X] Add option for selecting 'Between'.
- [x] Able to condition formatting on UI using between two values.
- [x] The file(s) or folder(s) now contain changes as specified in the issue I worked on.
- [x] Check build, test, lint and format by run running command `pnpm run build` at root directory.
- [x] I certify that I ran the checklist.

### Testing:

None

## Additional Notes:

None

## Closing

Closes #65 
