### PR TITLE
feat(core): add export services to pivot engine

### DIFF
--- a/examples/simple-js-demo/header/header.js
+++ b/examples/simple-js-demo/header/header.js
@@ -4,6 +4,12 @@ import { conditionFormattingPopUp } from '../services/conditionFormattingPopUp.j
 import { createFieldsPopup } from '../services/fieldsPopup.js';
 import { dataSourceOptions } from '../services/dataSourceOptions.js';
 import { pivotEngine } from '../index.js';
+import {
+  exportToHTML,
+  exportToExcel,
+  exportToPDF,
+  openPrintDialog,
+} from '../services/exportService.js';
 
 export function createHeader(config) {
   const header = document.createElement('div');
@@ -83,7 +89,20 @@ export function createHeader(config) {
               dataSourceOptions(config);
               break;
             case 'Print':
-              window.print();
+              dropdown.style.display = 'none';
+              openPrintDialog(pivotEngine);
+              break;
+            case 'To HTML':
+              dropdown.style.display = 'none';
+              exportToHTML(pivotEngine);
+              break;
+            case 'To Excel':
+              dropdown.style.display = 'none';
+              exportToExcel(pivotEngine);
+              break;
+            case 'To PDF':
+              dropdown.style.display = 'none';
+              exportToPDF(pivotEngine);
               break;
             default:
               alert(optionName + ` is under development`);

--- a/examples/simple-js-demo/services/exportService.js
+++ b/examples/simple-js-demo/services/exportService.js
@@ -1,0 +1,15 @@
+export function exportToHTML(pivotEngine, fileName = 'pivot-table') {
+  pivotEngine.exportToHTML(fileName);
+}
+
+export function exportToExcel(pivotEngine, fileName = 'pivot-table') {
+  pivotEngine.exportToExcel(fileName);
+}
+
+export function exportToPDF(pivotEngine, fileName = 'pivot-table') {
+  pivotEngine.exportToPDF(fileName);
+}
+
+export function openPrintDialog(pivotEngine) {
+  pivotEngine.openPrintDialog();
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,5 +57,10 @@
     "vite": "^4.3.9",
     "vite-plugin-dts": "^2.3.0",
     "vitest": "^0.32.0"
+  },
+  "dependencies": {
+    "jspdf": "^3.0.1",
+    "jspdf-autotable": "^5.0.2",
+    "xlsx": "^0.18.5"
   }
 }

--- a/packages/core/src/engine/exportService.ts
+++ b/packages/core/src/engine/exportService.ts
@@ -1,0 +1,519 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as XLSX from 'xlsx';
+import { jsPDF } from 'jspdf';
+import { autoTable } from 'jspdf-autotable';
+import { PivotTableState } from '../types/interfaces';
+
+/**
+ * Service class for handling export operations for the PivotEngine
+ */
+export class PivotExportService {
+  /**
+   * Converts the pivot table data to HTML
+   * @param {PivotTableState<T>} state - The current state of the pivot table
+   * @returns {string} HTML string representation of the pivot table
+   */
+  public static convertToHtml<T extends Record<string, any>>(
+    state: PivotTableState<T>
+  ): string {
+    const { rows, columns, selectedMeasures, formatting, groups, data } = state;
+
+    if (!rows.length || !columns.length) {
+      return '<div>No data to display</div>';
+    }
+
+    // Get unique column values
+    const uniqueColumns = [
+      ...new Set(data.map(item => item[columns[0].uniqueName])),
+    ];
+
+    // Get unique row values
+    const uniqueRows = [...new Set(data.map(item => item[rows[0].uniqueName]))];
+
+    const formatValue = (value: any, formatConfig: any): string => {
+      if (value === 0) return '$0.00';
+      if (!value && value !== 0) return '';
+
+      if (formatConfig.type === 'currency') {
+        return new Intl.NumberFormat(formatConfig.locale, {
+          style: 'currency',
+          currency: formatConfig.currency,
+          minimumFractionDigits: formatConfig.decimals,
+          maximumFractionDigits: formatConfig.decimals,
+        }).format(value);
+      } else if (formatConfig.type === 'number') {
+        return new Intl.NumberFormat(formatConfig.locale, {
+          minimumFractionDigits: formatConfig.decimals,
+          maximumFractionDigits: formatConfig.decimals,
+        }).format(value);
+      }
+
+      return String(value);
+    };
+
+    // Determine cell background based on conditional formatting (placeholder function)
+    const getCellStyle = (value: any, measureName: string): string => {
+      return '';
+    };
+
+    // Create HTML string
+    let html = `
+  <div class="pivot-export">
+    <style>
+      .pivot-table {
+        border-collapse: collapse;
+        width: 100%;
+        font-family: Arial, sans-serif;
+      }
+      .pivot-table th, .pivot-table td {
+        border: 1px solid #ddd;
+        padding: 8px;
+        text-align: right;
+      }
+      .pivot-table th {
+        background-color: #f2f2f2;
+        font-weight: bold;
+        text-align: center;
+        position: relative;
+      }
+      .pivot-table .sort-icon::after {
+        content: "↕";
+        position: absolute;
+        right: 4px;
+        opacity: 0.5;
+      }
+      .pivot-table th.region-header {
+        border-bottom: none;
+      }
+      .pivot-table th.measure-header {
+        border-top: none;
+      }
+      .pivot-table .row-header {
+        text-align: left;
+        font-weight: bold;
+        background-color: #f9f9f9;
+      }
+      .pivot-table .corner-header {
+        background-color: #f2f2f2;
+        border-bottom: 1px solid #ddd;
+      }
+      .pagination {
+        margin-top: 15px;
+        font-family: Arial, sans-serif;
+      }
+      .export-info {
+        margin-top: 15px;
+        font-size: 0.8em;
+        color: #666;
+        font-family: Arial, sans-serif;
+      }
+    </style>
+    
+    <table class="pivot-table">
+      <thead>
+        <tr>
+          <th rowspan="2" class="corner-header">${
+            rows[0]?.caption || rows[0]?.uniqueName || ''
+          } /<br>Region</th>`;
+
+    // Add region headers
+    uniqueColumns.forEach(column => {
+      html += `<th colspan="${selectedMeasures.length}" class="region-header">${column}</th>`;
+    });
+
+    html += `
+        </tr>
+        <tr>`;
+
+    // Add measure headers under each region
+    uniqueColumns.forEach(column => {
+      selectedMeasures.forEach(measure => {
+        html += `<th class="measure-header sort-icon">${
+          measure.caption || measure.uniqueName
+        }</th>`;
+      });
+    });
+
+    html += `
+        </tr>
+      </thead>
+      <tbody>`;
+
+    // Add data rows
+    uniqueRows.forEach(row => {
+      html += `<tr>
+      <td class="row-header">${row}</td>`;
+
+      // Add cells for each column (region)
+      uniqueColumns.forEach(column => {
+        // Find the group that matches this row and column
+        const group = groups.find(g => g.key === `${row} - ${column}`);
+
+        selectedMeasures.forEach(measure => {
+          const measureKey = `sum_${measure.uniqueName}`;
+          let value = group ? group.aggregates[measureKey] : 0;
+
+          // Apply conditional formatting
+          const cellStyle = getCellStyle(value, measure.uniqueName);
+
+          // Format value according to measure settings
+          const formattedValue = formatValue(
+            value,
+            formatting[measure.uniqueName]
+          );
+
+          html += `<td${cellStyle}>${formattedValue}</td>`;
+        });
+      });
+
+      html += `</tr>`;
+    });
+
+    html += `
+      </tbody>
+    </table>
+    
+    <div class="pagination">
+      Page ${state.paginationConfig?.currentPage || 1} of ${
+        state.paginationConfig?.totalPages || 1
+      }
+    </div>
+    
+    <div class="export-info">
+      <p>Generated: ${new Date().toLocaleString()}</p>
+    </div>
+  </div>`;
+
+    return html;
+  }
+
+  /**
+   * Exports the pivot table data to HTML and downloads the file
+   * @param {PivotTableState<T>} state - The current state of the pivot table
+   * @param {string} fileName - The name of the downloaded file (without extension)
+   */
+  public static exportToHTML<T extends Record<string, any>>(
+    state: PivotTableState<T>,
+    fileName = 'pivot-table'
+  ): void {
+    const htmlContent = PivotExportService.convertToHtml(state);
+
+    const blob = new Blob([htmlContent], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${fileName}.html`;
+    document.body.appendChild(a);
+    a.click();
+
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  /**
+   * Exports the pivot table data to PDF and downloads the file
+   * @param {PivotTableState<T>} state - The current state of the pivot table
+   * @param {string} fileName - The name of the downloaded file (without extension)
+   */
+  public static exportToPDF<T extends Record<string, any>>(
+    state: PivotTableState<T>,
+    fileName = 'pivot-table'
+  ): void {
+    // Convert pivot data to an HTML table
+    const htmlContent = PivotExportService.convertToHtml(state);
+
+    // Create a temporary container for the HTML
+    const container = document.createElement('div');
+    container.style.position = 'absolute';
+    container.style.left = '-9999px'; // Hide off-screen
+    container.innerHTML = htmlContent;
+    document.body.appendChild(container);
+
+    // Extract the table from the container
+    const tableElement = container.querySelector('table');
+
+    if (!tableElement) {
+      console.error('No table found in the generated HTML');
+      document.body.removeChild(container);
+      return;
+    }
+
+    try {
+      // Create a new PDF document
+      const pdf = new jsPDF();
+
+      // Add title
+      pdf.setFontSize(16);
+      pdf.text(fileName, pdf.internal.pageSize.getWidth() / 2, 15, {
+        align: 'center',
+      });
+
+      // Use autoTable to convert the HTML table to PDF
+      autoTable(pdf, {
+        html: tableElement,
+        startY: 25,
+        styles: {
+          fontSize: 10,
+          cellPadding: 3,
+          overflow: 'linebreak',
+        },
+        headStyles: {
+          fillColor: [66, 139, 202],
+          textColor: 255,
+          fontStyle: 'bold',
+        },
+        columnStyles: {},
+        margin: { top: 25, right: 15, bottom: 25, left: 15 },
+        didDrawPage: (data: { pageNumber: number }) => {
+          pdf.setFontSize(10);
+          pdf.text(
+            `Page ${data.pageNumber}`,
+            pdf.internal.pageSize.getWidth() - 20,
+            pdf.internal.pageSize.getHeight() - 10
+          );
+        },
+      });
+
+      // Save the PDF
+      pdf.save(`${fileName}.pdf`);
+
+      // Clean up
+      document.body.removeChild(container);
+    } catch (error) {
+      console.error('Error exporting to PDF:', error);
+      document.body.removeChild(container);
+    }
+  }
+
+  /**
+   * Exports the pivot table data to Excel and downloads the file
+   * @param {PivotTableState<T>} state - The current state of the pivot table
+   * @param {string} fileName - The name of the downloaded file (without extension)
+   */
+  public static exportToExcel<T extends Record<string, any>>(
+    state: PivotTableState<T>,
+    fileName = 'pivot-table'
+  ): void {
+    try {
+      PivotExportService.generateExcel(state, fileName);
+    } catch (error) {
+      console.error('Error exporting to Excel:', error);
+    }
+  }
+
+  /**
+   * Generates an Excel file from the pivot table data
+   * @param {PivotTableState<T>} state - The current state of the pivot table
+   * @param {string} fileName - The name of the downloaded file (without extension)
+   */
+  private static generateExcel<T extends Record<string, any>>(
+    state: PivotTableState<T>,
+    fileName: string
+  ): void {
+    if (!state.data || state.data.length === 0) {
+      console.log('No data to export!');
+      return;
+    }
+
+    // Get dimension and measure configurations
+    const rows = state.rows || [];
+    const columns = state.columns || [];
+    const measures = state.measures || [];
+
+    // Extract unique dimension values
+    const rowDimension = rows[0]?.uniqueName;
+    const colDimension = columns[0]?.uniqueName;
+
+    if (!rowDimension || !colDimension) {
+      console.log('Missing row or column dimension');
+      return;
+    }
+
+    const uniqueRowValues = [
+      ...new Set(state.data.map(item => item[rowDimension])),
+    ];
+    const uniqueColValues = [
+      ...new Set(state.data.map(item => item[colDimension])),
+    ];
+
+    // Create header rows
+    const headerRow = [
+      rows[0]?.caption || 'Dimension',
+      ...uniqueColValues.flatMap(colValue =>
+        measures.map(
+          measure => `${colValue} - ${measure.caption || measure.uniqueName}`
+        )
+      ),
+    ];
+
+    // Create data rows
+    const dataRows = uniqueRowValues.map(rowValue => {
+      const row = [rowValue];
+
+      uniqueColValues.forEach(colValue => {
+        measures.forEach(measure => {
+          // Filter data for this row and column intersection
+          const filteredData = state.data.filter(
+            item =>
+              item[rowDimension] === rowValue && item[colDimension] === colValue
+          );
+
+          // Calculate the aggregated value
+          let value = 0;
+          if (filteredData.length > 0) {
+            switch (measure.aggregation) {
+              case 'sum':
+                value = filteredData.reduce(
+                  (sum, item) => sum + (item[measure.uniqueName] || 0),
+                  0
+                );
+                break;
+              case 'avg':
+                if (
+                  measure?.formula &&
+                  typeof measure.formula === 'function' &&
+                  filteredData.length > 0
+                ) {
+                  value =
+                    filteredData.reduce(
+                      (sum, item) => sum + (measure.formula?.(item) || 0),
+                      0
+                    ) / filteredData.length;
+                } else {
+                  value =
+                    filteredData.reduce(
+                      (sum, item) => sum + (item[measure.uniqueName] || 0),
+                      0
+                    ) / filteredData.length;
+                }
+                break;
+              case 'max':
+                value = Math.max(
+                  ...filteredData.map(item => item[measure.uniqueName] || 0)
+                );
+                break;
+              case 'min':
+                value = Math.min(
+                  ...filteredData.map(item => item[measure.uniqueName] || 0)
+                );
+                break;
+              case 'count':
+                value = filteredData.length;
+                break;
+              default:
+                value = 0;
+            }
+          }
+
+          // For Excel, we keep the raw numeric value
+          row.push(value);
+        });
+      });
+
+      return row;
+    });
+
+    // Add a totals row if available
+    if (state.processedData && state.processedData.totals) {
+      const totalsRow = ['Total'];
+
+      uniqueColValues.forEach(colValue => {
+        measures.forEach(measure => {
+          // Get total for this measure across all data
+          const totalValue =
+            state.processedData.totals[measure.uniqueName] || 0;
+          totalsRow.push(totalValue?.toString());
+        });
+      });
+
+      dataRows.push(totalsRow);
+    }
+
+    // Combine header and data rows
+    const allRows = [headerRow, ...dataRows];
+
+    // Create worksheet
+    const ws = XLSX.utils.aoa_to_sheet(allRows);
+
+    // Apply some basic styling
+    const range = XLSX.utils.decode_range(ws['!ref'] ?? 'A1:A1');
+
+    // Set column widths
+    const colWidths = [];
+    for (let i = 0; i <= range.e.c; i++) {
+      colWidths[i] = { wch: i === 0 ? 15 : 12 }; // First column wider, data columns standard
+    }
+    ws['!cols'] = colWidths;
+
+    // Apply number formatting for data cells
+    for (let row = 1; row <= dataRows.length; row++) {
+      for (
+        let col = 1;
+        col <= uniqueColValues.length * measures.length;
+        col++
+      ) {
+        const cellAddress = XLSX.utils.encode_cell({ r: row, c: col });
+
+        // Find the measure for this column
+        const measureIndex = (col - 1) % measures.length;
+        const measure = measures[measureIndex];
+
+        if (measure && measure.format && ws[cellAddress]) {
+          if (measure.format.type === 'currency') {
+            // Apply currency format
+            ws[cellAddress].z =
+              measure.format.currency === 'USD'
+                ? '"$"#,##0.00'
+                : `"${measure.format.currency}"#,##0.00`;
+          } else if (
+            measure.format.type === 'number' &&
+            measure.format.decimals !== undefined
+          ) {
+            // Apply decimal format
+            const format =
+              '#,##0' +
+              (measure.format.decimals > 0
+                ? '.' + '0'.repeat(measure.format.decimals)
+                : '');
+            ws[cellAddress].z = format;
+          } else if (measure.format.type === 'percentage') {
+            ws[cellAddress].z = '0.00%';
+            // Convert decimal to percentage for display
+            if (typeof ws[cellAddress].v === 'number') {
+              ws[cellAddress].v = ws[cellAddress].v / 100;
+            }
+          }
+        }
+      }
+    }
+
+    // Create workbook and add worksheet
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Pivot Table');
+
+    // Generate Excel file and download
+    XLSX.writeFile(wb, `${fileName}.xlsx`);
+  }
+
+  /**
+   * Opens a print dialog with formatted pivot table content
+   * @param {PivotTableState<T>} state - The current state of the pivot table
+   * @param {string} title - Optional title for the printed page
+   */
+  public static openPrintDialog<T extends Record<string, any>>(
+    state: PivotTableState<T>
+  ): void {
+    const htmlContent = PivotExportService.convertToHtml(state);
+
+    const printWindow = window.open('', '_blank');
+    if (!printWindow) {
+      console.error('Failed to open print dialog');
+      return;
+    }
+
+    printWindow.document.write(htmlContent);
+    printWindow.document.close();
+    printWindow.print();
+  }
+}

--- a/packages/core/src/engine/pivotEngine.ts
+++ b/packages/core/src/engine/pivotEngine.ts
@@ -15,6 +15,7 @@ import {
 } from '../types/interfaces';
 import { calculateAggregates } from './aggregator';
 import { processData } from './dataProcessor';
+import { PivotExportService } from './exportService';
 // import { applySort, sortGroups } from './sorter';
 
 /**
@@ -872,5 +873,40 @@ export class PivotEngine<T extends Record<string, any>> {
    */
   public getFilterState(): FilterConfig[] {
     return [...this.filterConfig];
+  }
+
+  /**
+   * Exports the pivot table data to HTML and downloads the file.
+   * @param {string} fileName - The name of the downloaded file (without extension).
+   * @public
+   */
+  public exportToHTML(fileName = 'pivot-table'): void {
+    PivotExportService.exportToHTML(this.getState(), fileName);
+  }
+
+  /**
+   * Exports the pivot table data to PDF and downloads the file.
+   * @param {string} fileName - The name of the downloaded file (without extension).
+   * @public
+   */
+  public exportToPDF(fileName = 'pivot-table'): void {
+    PivotExportService.exportToPDF(this.getState(), fileName);
+  }
+
+  /**
+   * Exports the pivot table data to Excel and downloads the file.
+   * @param {string} fileName - The name of the downloaded file (without extension).
+   * @public
+   */
+  public exportToExcel(fileName = 'pivot-table'): void {
+    PivotExportService.exportToExcel(this.getState(), fileName);
+  }
+
+  /**
+   * Opens a print dialog with the formatted pivot table.
+   * @public
+   */
+  public openPrintDialog(): void {
+    PivotExportService.openPrintDialog(this.getState());
   }
 }


### PR DESCRIPTION
# Pull Request Description

This pull request addresses the following issue:

**Feature**: [GitHub Issue #140](https://github.com/mindfiredigital/PivotHead/issues/140)

### Changes Made:

- Add exportService utility class inside core 
- Use the exportService methods inside pivot engine 
- Create a wrapper service inside simple-js-demo and use it inside header.js

### Checklist:

- [ ] Add a new file exportService.ts inside core which have exportToHTML, exportToPDF, exportToExcel and openPrintDialog
- [ ] Use this above utility methods inside the core pivotEngine.ts
- [ ] Update options and add actions inside header.js inside simple-js-demo
- [ ] Check build, test, lint and format by run running command pnpm run build at root directory.

### Closing:
Closes:  [#140](https://github.com/mindfiredigital/PivotHead/issues/140)