### PR TITLE
feat(core): add unit test for export services to pivot engine

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,6 +59,7 @@
     "vitest": "^0.32.0"
   },
   "dependencies": {
+    "jsdom": "^26.0.0",
     "jspdf": "^3.0.1",
     "jspdf-autotable": "^5.0.2",
     "xlsx": "^0.18.5"

--- a/packages/core/src/__test__/exportService.test.ts
+++ b/packages/core/src/__test__/exportService.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PivotExportService } from '../engine/exportService';
+import * as XLSX from 'xlsx';
+import { jsPDF } from 'jspdf';
+import { PivotTableState } from '../types/interfaces';
+
+// Mock dependencies
+vi.mock('xlsx', () => ({
+  utils: {
+    aoa_to_sheet: vi.fn().mockReturnValue({}),
+    book_new: vi.fn().mockReturnValue({}),
+    book_append_sheet: vi.fn(),
+    decode_range: vi.fn().mockReturnValue({ e: { c: 5 } }),
+    encode_cell: vi
+      .fn()
+      .mockImplementation(
+        ({ r, c }) => `${String.fromCharCode(65 + c)}${r + 1}`
+      ),
+  },
+  writeFile: vi.fn(),
+}));
+
+vi.mock('jspdf', () => ({
+  jsPDF: vi.fn().mockImplementation(() => ({
+    setFontSize: vi.fn(),
+    text: vi.fn(),
+    save: vi.fn(),
+    internal: {
+      pageSize: {
+        getWidth: vi.fn().mockReturnValue(210),
+        getHeight: vi.fn().mockReturnValue(297),
+      },
+    },
+  })),
+}));
+
+vi.mock('jspdf-autotable', () => ({
+  autoTable: vi.fn(),
+}));
+
+describe('PivotExportService', () => {
+  // Mock document methods
+  beforeEach(() => {
+    // Mock document methods
+    document.createElement = vi.fn().mockImplementation(tag => {
+      if (tag === 'a') {
+        return {
+          href: '',
+          download: '',
+          click: vi.fn(),
+          style: {},
+        };
+      }
+      if (tag === 'div') {
+        return {
+          style: {},
+          innerHTML: '',
+          querySelector: vi.fn().mockReturnValue({ style: {} }),
+        };
+      }
+      return {};
+    });
+    document.body.appendChild = vi.fn();
+    document.body.removeChild = vi.fn();
+    URL.createObjectURL = vi.fn().mockReturnValue('blob:mock-url');
+    URL.revokeObjectURL = vi.fn();
+    window.open = vi.fn().mockReturnValue({
+      document: {
+        open: vi.fn(),
+        write: vi.fn(),
+        close: vi.fn(),
+      },
+      focus: vi.fn(),
+      print: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Sample state for testing - Properly typed with all required properties
+  const createMockState = (isEmpty = false): PivotTableState<any> => ({
+    data: isEmpty
+      ? []
+      : [
+          { product: 'Product A', region: 'North', sales: 100, profit: 25 },
+          { product: 'Product B', region: 'North', sales: 150, profit: 40 },
+          { product: 'Product A', region: 'South', sales: 200, profit: 50 },
+          { product: 'Product B', region: 'South', sales: 250, profit: 60 },
+        ],
+    processedData: {
+      headers: ['Product', 'Region'],
+      rows: [],
+      totals: { sales: 700, profit: 175 },
+    },
+    rows: [{ uniqueName: 'product', caption: 'Product' }],
+    columns: [{ uniqueName: 'region', caption: 'Region' }],
+    measures: [
+      { uniqueName: 'sales', caption: 'Sales', aggregation: 'sum' },
+      { uniqueName: 'profit', caption: 'Profit', aggregation: 'sum' },
+    ],
+    selectedMeasures: [
+      { uniqueName: 'sales', caption: 'Sales', aggregation: 'sum' },
+      { uniqueName: 'profit', caption: 'Profit', aggregation: 'sum' },
+    ],
+    selectedDimensions: [],
+    selectedAggregation: 'sum',
+    formatting: {
+      sales: { type: 'number', decimals: 0, locale: 'en-US' },
+      profit: {
+        type: 'currency',
+        currency: 'USD',
+        decimals: 2,
+        locale: 'en-US',
+      },
+    },
+    groups: [
+      {
+        key: 'Product A - North',
+        items: [],
+        aggregates: { sum_sales: 100, sum_profit: 25 },
+      },
+      {
+        key: 'Product B - North',
+        items: [],
+        aggregates: { sum_sales: 150, sum_profit: 40 },
+      },
+      {
+        key: 'Product A - South',
+        items: [],
+        aggregates: { sum_sales: 200, sum_profit: 50 },
+      },
+      {
+        key: 'Product B - South',
+        items: [],
+        aggregates: { sum_sales: 250, sum_profit: 60 },
+      },
+    ],
+    sortConfig: [],
+    rowSizes: [],
+    expandedRows: {},
+    groupConfig: null,
+    columnWidths: {},
+    isResponsive: true,
+    rowGroups: [],
+    columnGroups: [],
+    filterConfig: [],
+    paginationConfig: {
+      currentPage: 1,
+      totalPages: 1,
+      pageSize: 10,
+    },
+  });
+
+  describe('convertToHtml', () => {
+    it('should convert state to HTML representation', () => {
+      const state = createMockState();
+      const html = PivotExportService.convertToHtml(state);
+
+      // Verify HTML structure
+      expect(html).toContain('<table class="pivot-table">');
+      expect(html).toContain(
+        '<th rowspan="2" class="corner-header">Product /<br>Region</th>'
+      );
+      expect(html).toContain('North');
+      expect(html).toContain('South');
+      expect(html).toContain('Sales');
+      expect(html).toContain('Profit');
+    });
+
+    it('should handle empty data', () => {
+      const state = createMockState(true);
+      const html = PivotExportService.convertToHtml(state);
+      expect(html).toContain('No data to display');
+    });
+
+    it('should include pagination information', () => {
+      const state = createMockState();
+      state.paginationConfig.currentPage = 2;
+      state.paginationConfig.totalPages = 5;
+
+      const html = PivotExportService.convertToHtml(state);
+      expect(html).toContain('Page 2 of 5');
+    });
+  });
+
+  describe('exportToHTML', () => {
+    it('should create a Blob and trigger download', () => {
+      const state = createMockState();
+      PivotExportService.exportToHTML(state, 'test-file');
+
+      // Check if Blob was created
+      expect(URL.createObjectURL).toHaveBeenCalled();
+
+      expect(document.createElement).toHaveBeenCalledWith('a');
+
+      expect(document.body.appendChild).toHaveBeenCalled();
+      expect(document.body.removeChild).toHaveBeenCalled();
+      expect(URL.revokeObjectURL).toHaveBeenCalled();
+    });
+  });
+
+  describe('exportToPDF', () => {
+    it('should create a PDF and save it', () => {
+      const state = createMockState();
+      PivotExportService.exportToPDF(state, 'test-file');
+
+      // Check if container was created
+      expect(document.createElement).toHaveBeenCalledWith('div');
+      expect(document.body.appendChild).toHaveBeenCalled();
+
+      // Check if jsPDF was initialized
+      expect(jsPDF).toHaveBeenCalled();
+
+      // Check if PDF was saved
+      const mockJsPDF = jsPDF as unknown as ReturnType<typeof vi.fn>;
+      const pdfInstance = mockJsPDF.mock.results[0].value;
+      expect(pdfInstance.save).toHaveBeenCalledWith('test-file.pdf');
+
+      // Check cleanup
+      expect(document.body.removeChild).toHaveBeenCalled();
+    });
+
+    it('should handle case when table element is not found', () => {
+      const state = createMockState();
+
+      // Mock querySelector to return null
+      document.createElement = vi.fn().mockImplementation(() => ({
+        style: {},
+        innerHTML: '',
+        querySelector: vi.fn().mockReturnValue(null),
+      }));
+
+      // Mock console.error
+      const originalConsoleError = console.error;
+      console.error = vi.fn();
+
+      PivotExportService.exportToPDF(state);
+
+      expect(console.error).toHaveBeenCalledWith(
+        'No table found in the generated HTML'
+      );
+      expect(document.body.removeChild).toHaveBeenCalled();
+
+      // Restore console.error
+      console.error = originalConsoleError;
+    });
+  });
+
+  describe('exportToExcel', () => {
+    it('should create an Excel file and save it', () => {
+      const state = createMockState();
+      PivotExportService.exportToExcel(state, 'test-file');
+
+      // Check if Excel workbook was created
+      expect(XLSX.utils.book_new).toHaveBeenCalled();
+      expect(XLSX.utils.aoa_to_sheet).toHaveBeenCalled();
+      expect(XLSX.utils.book_append_sheet).toHaveBeenCalled();
+
+      // Check if file was saved
+      expect(XLSX.writeFile).toHaveBeenCalledWith(
+        expect.anything(),
+        'test-file.xlsx'
+      );
+    });
+
+    it('should handle empty data', () => {
+      const state = createMockState(true);
+      const consoleLogSpy = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => {});
+
+      PivotExportService.exportToExcel(state);
+
+      expect(console.log).toHaveBeenCalledWith('No data to export!');
+      expect(XLSX.writeFile).not.toHaveBeenCalled();
+
+      consoleLogSpy.mockRestore();
+    });
+
+    it('should handle missing dimension configuration', () => {
+      const state = createMockState();
+      state.rows = [];
+
+      const consoleLogSpy = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => {});
+
+      PivotExportService.exportToExcel(state);
+
+      expect(console.log).toHaveBeenCalledWith(
+        'Missing row or column dimension'
+      );
+      expect(XLSX.writeFile).not.toHaveBeenCalled();
+
+      consoleLogSpy.mockRestore();
+    });
+
+    it('should apply correct formatting to Excel cells', () => {
+      const state = createMockState();
+
+      // Add a percentage measure
+      state.measures.push({
+        uniqueName: 'margin',
+        caption: 'Margin',
+        aggregation: 'sum',
+      });
+      state.selectedMeasures.push({
+        uniqueName: 'margin',
+        caption: 'Margin',
+        aggregation: 'sum',
+      });
+      state.formatting.margin = { type: 'percentage', decimals: 2 };
+
+      PivotExportService.exportToExcel(state);
+
+      // Check cell formatting was applied
+      // This is a bit tricky to test without deeper mocking
+      expect(XLSX.utils.aoa_to_sheet).toHaveBeenCalled();
+      expect(XLSX.utils.decode_range).toHaveBeenCalled();
+    });
+  });
+
+  describe('openPrintDialog', () => {
+    it('should open a new window with formatted content', () => {
+      const state = createMockState();
+      PivotExportService.openPrintDialog(state);
+
+      // Check if window was opened
+      expect(window.open).toHaveBeenCalled();
+    });
+
+    it('should handle error if window cannot be opened', () => {
+      const state = createMockState();
+
+      // Mock window.open to return null (blocked popup)
+      window.open = vi.fn().mockReturnValue(null);
+
+      // Mock console.error
+      const originalConsoleError = console.error;
+      console.error = vi.fn();
+
+      PivotExportService.openPrintDialog(state);
+
+      expect(console.error).toHaveBeenCalledWith('Failed to open print dialog');
+
+      // Restore console.error
+      console.error = originalConsoleError;
+    });
+  });
+});

--- a/packages/core/src/engine/exportService.ts
+++ b/packages/core/src/engine/exportService.ts
@@ -18,6 +18,10 @@ export class PivotExportService {
   ): string {
     const { rows, columns, selectedMeasures, formatting, groups, data } = state;
 
+    if (data.length === 0) {
+      return '<div>No data to display</div>';
+    }
+
     if (!rows.length || !columns.length) {
       return '<div>No data to display</div>';
     }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -4,7 +4,7 @@ import { resolve } from 'path';
 export default defineConfig({
   test: {
     globals: true,
-    environment: 'node',
+    environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
   },
   resolve: {


### PR DESCRIPTION
# Pull Request Description

This pull request addresses the following issue:

**Feature**: [GitHub Issue #144](https://github.com/mindfiredigital/PivotHead/issues/144)

### Changes Made:

- Add exportService.test.ts
- Add unit test for exportToHTML, exportToPDF , exportToExcel and openPrintDialog
- Add missing check in  exportToHTML when data is empty

## Screenshots (if appropriate):
![Screenshot (11)](https://github.com/user-attachments/assets/e2e2f1e6-d16c-404e-9b6e-0161b740e23a)


### Checklist:

- [ ] Add exportService.test.ts
- [ ] Add unit test for exportToHTML, exportToPDF , exportToExcel and openPrintDialog
- [ ] Check build, test, lint and format by run running command `pnpm run build` at root directory.
- [ ] I certify that I ran the checklist.

## Closing

Closes # [144](https://github.com/mindfiredigital/PivotHead/issues/144)
